### PR TITLE
Use jquery instead of d3 to remove panels.

### DIFF
--- a/consentrecords/static/b/consentrecords/js/pathtreePanel.js
+++ b/consentrecords/static/b/consentrecords/js/pathtreePanel.js
@@ -2133,7 +2133,7 @@ var AddOptions = (function () {
 									   $(panel.node()).hide("slide", {direction: "down"}, 200))
 								 .then(function()
 									{
-										panel.remove();
+										$(panel.node()).remove();
 										clickFunction();
 									});
 							}


### PR DESCRIPTION
d3 has a bug that throws an exception when removing a div that has
display: none.